### PR TITLE
Fix package install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install --user https://github.com/stencila/py/archive/master.zip
 Then install the package so that other Stencila packages and applications can detect it:
 
 ```bash
-python -c "import stencila; stencila.install()"
+python -c "import stencila; stencila.register()"
 ```
 
 ### Use


### PR DESCRIPTION
Update the README to run `stencila.register()` instead of `stencila.install()`. Name changed in be791dced5e1c376b7933e199a95502556c73b2d